### PR TITLE
Add commands persistence

### DIFF
--- a/backend/chainlit/types.py
+++ b/backend/chainlit/types.py
@@ -282,6 +282,8 @@ class CommandDict(TypedDict):
     icon: str
     # Display the command as a button in the composer
     button: Optional[bool]
+    # Whether the command will be persistent unless the user toggles it
+    persistent: Optional[bool]
 
 
 class FeedbackDict(TypedDict):

--- a/frontend/src/components/chat/MessageComposer/CommandButtons.tsx
+++ b/frontend/src/components/chat/MessageComposer/CommandButtons.tsx
@@ -32,10 +32,9 @@ export const CommandButtons = ({
     <div className="flex gap-2 ml-1 flex-wrap">
       <TooltipProvider>
         {commandButtons.map((command) => (
-          <Tooltip>
+          <Tooltip key={command.id}>
             <TooltipTrigger asChild>
               <Button
-                key={command.id}
                 id={`command-${command.id}`}
                 variant="ghost"
                 disabled={disabled}

--- a/frontend/src/components/chat/MessageComposer/Input.tsx
+++ b/frontend/src/components/chat/MessageComposer/Input.tsx
@@ -97,7 +97,9 @@ const Input = forwardRef<InputMethods, Props>(
     };
 
     const reset = () => {
-      setSelectedCommand(undefined);
+      if (!selectedCommand?.persistent) {
+        setSelectedCommand(undefined);
+      }
       setSelectedIndex(0);
       setCommandInput('');
       if (contentEditableRef.current) {

--- a/frontend/src/components/chat/MessageComposer/index.tsx
+++ b/frontend/src/components/chat/MessageComposer/index.tsx
@@ -5,7 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import {
   FileSpec,
-  ICommand,
   IStep,
   useAuth,
   useChatData,
@@ -16,7 +15,11 @@ import { Settings } from '@/components/icons/Settings';
 import { Button } from '@/components/ui/button';
 
 import { chatSettingsOpenState } from '@/state/project';
-import { IAttachment, attachmentsState } from 'state/chat';
+import {
+  IAttachment,
+  attachmentsState,
+  persistentCommandState
+} from 'state/chat';
 
 import { Attachments } from './Attachments';
 import CommandButtons from './CommandButtons';
@@ -42,7 +45,9 @@ export default function MessageComposer({
 }: Props) {
   const inputRef = useRef<InputMethods>(null);
   const [value, setValue] = useState('');
-  const [selectedCommand, setSelectedCommand] = useState<ICommand>();
+  const [selectedCommand, setSelectedCommand] = useRecoilState(
+    persistentCommandState
+  );
   const setChatSettingsOpen = useSetRecoilState(chatSettingsOpenState);
   const [attachments, setAttachments] = useRecoilState(attachmentsState);
   const { t } = useTranslation();

--- a/frontend/src/state/chat.ts
+++ b/frontend/src/state/chat.ts
@@ -1,5 +1,7 @@
 import { atom } from 'recoil';
 
+import { ICommand } from 'client-types/*';
+
 export interface IAttachment {
   id: string;
   serverId?: string;
@@ -15,4 +17,9 @@ export interface IAttachment {
 export const attachmentsState = atom<IAttachment[]>({
   key: 'Attachments',
   default: []
+});
+
+export const persistentCommandState = atom<ICommand | undefined>({
+  key: 'PersistentCommand',
+  default: undefined
 });

--- a/libs/react-client/src/types/command.ts
+++ b/libs/react-client/src/types/command.ts
@@ -3,4 +3,5 @@ export interface ICommand {
   icon: string;
   description: string;
   button?: boolean;
+  persistent?: boolean;
 }


### PR DESCRIPTION
This pull request introduces a new feature to support persistent commands in the chat message composer. The changes span both the backend and frontend codebases, adding the necessary types, state management, and UI updates to handle persistent commands.

### Backend Changes:
* [`backend/chainlit/types.py`](diffhunk://#diff-9feb39b471289c6ef43961ab57fa796d091c790be59c90f3351c4253fa66512dR284-R285): Added a `persistent` field to the `CommandDict` type to indicate whether a command should remain active until toggled by the user.

### Frontend Changes:
* [`frontend/src/components/chat/MessageComposer/CommandButtons.tsx`](diffhunk://#diff-8b96b67b52a3f1a8fd66eb5ecd133c633d29ff7ad73cc2eb1eb382c384610c2eL35-L38): Added a `key` attribute to the `Tooltip` component to ensure each command button has a unique key.
* [`frontend/src/components/chat/MessageComposer/CommandPopoverButton.tsx`](diffhunk://#diff-ac9dbd64796c50d0fd6c9cc801d954a77d9f63b24da76fc5a64b36ed239fb78bL35-R37): Filtered out commands that are displayed as buttons and added a check to ensure the command list is not empty.
* [`frontend/src/components/chat/MessageComposer/Input.tsx`](diffhunk://#diff-a6bb57817304c99a5d25d091563906af0bf65cd3676836fb7aac92f066f142baR100-R102): Modified the reset function to only clear the selected command if it is not persistent.
* [`frontend/src/components/chat/MessageComposer/index.tsx`](diffhunk://#diff-f603b49a978423aba6e77034f65c84aa6a0d868c61c0a267c5dceb44d2dfb819L8): Updated imports and replaced the local state for `selectedCommand` with a Recoil state to manage persistent commands. [[1]](diffhunk://#diff-f603b49a978423aba6e77034f65c84aa6a0d868c61c0a267c5dceb44d2dfb819L8) [[2]](diffhunk://#diff-f603b49a978423aba6e77034f65c84aa6a0d868c61c0a267c5dceb44d2dfb819L19-R22) [[3]](diffhunk://#diff-f603b49a978423aba6e77034f65c84aa6a0d868c61c0a267c5dceb44d2dfb819L45-R50)

### State Management:
* [`frontend/src/state/chat.ts`](diffhunk://#diff-821401cbf8f91acfc7c9aac12260f6b1d41ce3650b5d12ef38ebca3ff55255f3R3-R4): Introduced a new Recoil atom `persistentCommandState` to manage the state of persistent commands. [[1]](diffhunk://#diff-821401cbf8f91acfc7c9aac12260f6b1d41ce3650b5d12ef38ebca3ff55255f3R3-R4) [[2]](diffhunk://#diff-821401cbf8f91acfc7c9aac12260f6b1d41ce3650b5d12ef38ebca3ff55255f3R21-R25)

### Types:
* [`libs/react-client/src/types/command.ts`](diffhunk://#diff-fc2455ffd977138fa703bd374602f0e1dd40c44a0f8ceee57b683b868bb31cfdR6): Added a `persistent` field to the `ICommand` interface to define whether a command is persistent.